### PR TITLE
Fix compile failures with gcc 4.9.2

### DIFF
--- a/pletter/pletter.cpp
+++ b/pletter/pletter.cpp
@@ -10,6 +10,7 @@
 */
 
 #include <string>
+#include <stdlib.h>
 using namespace std;
 
 /*


### PR DESCRIPTION
    >gmake
    g++ -O2 -Wall -fomit-frame-pointer bin2h.c -o bin2h
    g++    -c -o pletter/pletter.o pletter/pletter.cpp
    pletter/pletter.cpp: In destructor 'combstream::~combstream()':
    pletter/pletter.cpp:46:35: error: 'free' was not declared in this scope
       ~combstream() { if(buf) free(buf); }

    pletter/pletter.cpp: In member function 'void combstream::init()':
    pletter/pletter.cpp:49:40: error: 'malloc' was not declared in this scope
         buf=(unsigned char*)malloc(length*2);

    pletter/pletter.cpp: In function 'void pletter(unsigned char*, int, unsigned char**, int*, int)':
    pletter/pletter.cpp:329:45: error: 'malloc' was not declared in this scope
       buffer=(unsigned char*)malloc(input_length);

    pletter/pletter.cpp:345:14: error: 'free' was not declared in this scope
       free(buffer);

    <builtin>: recipe for target 'pletter/pletter.o' failed
    gmake: *** [pletter/pletter.o] Error 1