### PR TITLE
Add support for reverting rom conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,12 @@ bin2h: bin2h.c
 
 pletter/pletter.o: pletter/pletter.cpp
 
+pletter/unpletter.o: pletter/unpletter.c
+
 dsk2rom.h: bin2h
 	$(shell ./${bin2h_e} dsk2rom dsk2rom.rom dsk2rom.h)
 
-dsk2rom: dsk2rom.c pletter/pletter.o
+dsk2rom: dsk2rom.c pletter/pletter.o pletter/unpletter.o
 	$(CC) $(CFLAGS) $^ -o $(dsk2rom_e)
 
 clean:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ rom, and the -f option to create rom images in standard sizes (2^sizes).
 This should be enough info to start converting .dsk images to .rom images.
 Good luck!
 
+### Reverse to .dsk support
+
+A -r option has been added to allow to create back a dsk image from a rom created
+using dsk2rom tool. All compression modes are supported and roms with safe mode are
+also supported.
+
+example of creating a .dsk image from a .rom created with dsk2rom tool
+
+ * `dsk2rom -r alesteg.rom alesteg.dsk`
+
 ### Acknowledgements and thanks
 
 DSK2ROM by Vincent van Dam. The kernel was based on the disassembled diskroms
@@ -76,6 +86,8 @@ made by Sjoerd Mastijn, which was based on Bitbuster by Arjan Bakker. A thank
 you to Arturo Ragozini for suggesting to use pletter compression. A lot of
 thanks go to Ramones for his testing and diskrom kernel hacking, and not to
 forget his GETDPB implementation included in the kernel.
+Thanks to Sylvain Glaize who wrote the c implementation of pletter decompression
+allowing to revert pletter compressed roms : https://gitea.zaclys.com/Mokona/Unpletter .
 
 ### Version history
 

--- a/dsk2rom.c
+++ b/dsk2rom.c
@@ -47,7 +47,7 @@ void showUsage(char *progname)
          " -d   disable exclusive diskrom mode (other diskroms will boot too)\n"
          " -s   safe mode (protect against illegal bank switching)\n"
          " -f   fill up rom to standard rom size\n"
-         " -r   revert rom convertion (create dsk image from previously converted rom)"
+         " -r   revert rom convertion (create dsk image from previously converted rom)\n"
          " -v   give verbose information\n", progname);
   return;
 }

--- a/dsk2rom.c
+++ b/dsk2rom.c
@@ -47,7 +47,7 @@ void showUsage(char *progname)
          " -d   disable exclusive diskrom mode (other diskroms will boot too)\n"
          " -s   safe mode (protect against illegal bank switching)\n"
          " -f   fill up rom to standard rom size\n"
-         " -r   revert rom convertion (create dsk image from previously converted rom)\n"
+         " -r   revert rom conversion (create dsk image from previously converted rom)\n"
          " -v   give verbose information\n", progname);
   return;
 }

--- a/pletter/unpletter.c
+++ b/pletter/unpletter.c
@@ -1,0 +1,93 @@
+/* Modified by Sylver Bruneau from code by Sylvain Glaize : */
+/* https://gitea.zaclys.com/Mokona/Unpletter/               */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "unpletter.h"
+
+typedef unsigned char data_type;
+
+static data_type getByte(struct Uncompressor* uncompressor)
+{
+    return uncompressor->compressedData[uncompressor->dataPosition++];
+}
+
+static data_type getBit(struct Uncompressor* uncompressor)
+{
+    if (uncompressor->bitForVarPosition == 7)
+    {
+        uncompressor->varPosition = uncompressor->dataPosition;
+        uncompressor->dataPosition = uncompressor->varPosition + 1;
+    }
+
+    data_type bit = (uncompressor->compressedData[uncompressor->varPosition] >> uncompressor->bitForVarPosition) & 1;
+    uncompressor->bitForVarPosition--;
+
+    if (uncompressor->bitForVarPosition == -1)
+    {
+        uncompressor->bitForVarPosition = 7;
+    }
+    return bit;
+}
+
+static int getInterlacedEliasGamma(struct Uncompressor* uncompressor)
+{
+    int value = 1;
+    while (getBit(uncompressor))
+    {
+        value = (value << 1) | getBit(uncompressor);
+    }
+    return value;
+}
+
+unsigned char * realloc_output(unsigned char * output, size_t output_position, size_t * output_max_size, size_t add_data_size)
+{
+    if (output_position + add_data_size > *output_max_size)
+    {
+        *output_max_size *= 2;
+        output = (unsigned char*) realloc(output, *output_max_size);
+    }
+    return output;
+}
+
+void uncompress(struct Uncompressor* uncompressor, size_t in_data_length, unsigned char *out_data)
+{
+    size_t output_position = 0;
+
+    data_type first_byte = getByte(uncompressor);
+    out_data[output_position++] = first_byte;
+
+    while (uncompressor->dataPosition < in_data_length)
+    {
+        if (getBit(uncompressor))
+        {
+            int length = getInterlacedEliasGamma(uncompressor) + 1;
+
+            if (length == 262143 || (length == 131072))
+            {
+                break;
+            }
+
+            int offset = getByte(uncompressor);
+            if (offset & 0x80)
+            {
+                offset = offset & 0x7F;
+                offset = offset | (getBit(uncompressor) << 8);
+                offset = offset | (getBit(uncompressor) << 7);
+                offset += 128;
+            }
+            offset += 1;
+
+            for (int i = 0; i < length; i++)
+            {
+                out_data[output_position] = out_data[output_position - offset];
+                output_position += 1;
+            }
+        }
+        else
+        {
+            out_data[output_position++] = getByte(uncompressor);
+        }
+        if (output_position >= 512) break;
+    }
+}

--- a/pletter/unpletter.h
+++ b/pletter/unpletter.h
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+struct Uncompressor {
+    unsigned char* compressedData;
+    int dataPosition;
+    int varPosition;
+    int bitForVarPosition;
+};
+
+void uncompress(struct Uncompressor* uncompressor, size_t in_data_length, unsigned char *out_data);


### PR DESCRIPTION
Hello, this patch is adding a -r option to dsk2rom. The goal of this option is to allow creating back a .dsk image from a .rom image created by dsk2rom tool.
It supports roms created with any compression mode (0/1/2) and roms created with safe mode are also supported.
